### PR TITLE
updata simpleTree to add the attribute id to the node

### DIFF
--- a/simpleTree.js
+++ b/simpleTree.js
@@ -373,6 +373,7 @@ $.fn.simpleTree = function(options, data) {
         div.append($('<div/>').addClass(_options.css.indent).css({ 
             width: (node.children.length > 0 ? node.indent : (node.indent + 1)) * _options.indentSize 
         }));
+        if( node.id ) div.attr('id',node.id);
         if(node.children.length > 0) {
             node.domToggle = $('<div/>')
                 .css({ width: _options.indentSize })


### PR DESCRIPTION
to catch the exact node selected i add as ID attrubute to each node in the datapack pass to simpleTree.
on select event i can retrive the node ID just calling 
var myParentId=$(this).parent().attr('id');

ID attribute must be unique but are more usable by code than label.